### PR TITLE
Allow to skip request validation in API in development environment

### DIFF
--- a/Sources/App/Controllers/API/UserController.swift
+++ b/Sources/App/Controllers/API/UserController.swift
@@ -24,7 +24,7 @@ class UserController: RouteCollection {
     // MARK: Request Handlers
     
     func register(_ req: Request, _ registerRequest: RegisterUserRequest) throws -> Future<HTTPResponse> {
-        try registerRequest.validate()
+        try req.validate(registerRequest)
         
         return User.query(on: req)
             .filter(\User.username == registerRequest.username)

--- a/Sources/App/Services/ValidatorService.swift
+++ b/Sources/App/Services/ValidatorService.swift
@@ -1,0 +1,12 @@
+import Vapor
+
+typealias ValidatableContent = Content & Validatable & Reflectable
+
+struct ValidatorService: Service {
+    var skipValidation: Bool = false
+    
+    func validate<T: ValidatableContent>(_ validatable: T) throws -> Void {
+        guard !self.skipValidation else { return }
+        try validatable.validate()
+    }
+}

--- a/Sources/App/Services/ValidatorService.swift
+++ b/Sources/App/Services/ValidatorService.swift
@@ -2,6 +2,10 @@ import Vapor
 
 typealias ValidatableContent = Content & Validatable & Reflectable
 
+enum ValidatorServiceError: Error {
+    case validatorNotRegistered
+}
+
 struct ValidatorService: Service {
     var skipValidation: Bool = false
     

--- a/Sources/App/Services/ValidatorService.swift
+++ b/Sources/App/Services/ValidatorService.swift
@@ -6,11 +6,53 @@ enum ValidatorServiceError: Error {
     case validatorNotRegistered
 }
 
+/// Service responsible for validating request body, query or parameters.
+///
+/// Validation can be disabled by setting `skipValidation` to `true`.
 struct ValidatorService: Service {
+    
+    /// Allows to skip validation of each Content passed to `validate` function.
+    ///
+    /// - Note:
+    /// `skipValidation` does not affect Content types that were added explicitly by calling `forceValidation(of:)`
     var skipValidation: Bool = false
     
+    private var ignoredContents: [Any.Type] = []
+    private var forcedContents: [Any.Type] = []
+    
+    /// Allows to ignore validation of provided type even if the validation is enabled
+    mutating func ignoreValidation<T: ValidatableContent>(of validatableType: T.Type) {
+        guard !self.ignoredContents.contains(where: { $0 == validatableType }) else { return }
+        self.ignoredContents.append(validatableType)
+    }
+    
+    /// Allows to force validation of provided type even if the validation is disabled
+    mutating func forceValidation<T: ValidatableContent>(of validatableType: T.Type) {
+        guard !self.forcedContents.contains(where: { $0 == validatableType }) else { return }
+        self.forcedContents.append(validatableType)
+    }
+    
+    /// Validates the model, throwing an error if any of the validations fail.
+    ///
+    /// - Parameters:
+    ///     - validatable: Content to validate
+    ///
+    /// Non-validation errors may also be thrown should the validators encounter unexpected errors.
     func validate<T: ValidatableContent>(_ validatable: T) throws -> Void {
-        guard !self.skipValidation else { return }
+        guard self.shouldValidate(validatable) else { return }
         try validatable.validate()
+    }
+    
+    private func shouldValidate<T: ValidatableContent>(_ validatable: T) -> Bool {
+        let validatableType = type(of: validatable)
+        
+        if self.forcedContents.contains(where: { $0 == validatableType }) {
+            return true
+        }
+        if self.skipValidation {
+            return false
+        }
+        
+        return !self.ignoredContents.contains(where: { $0 == validatableType} )
     }
 }

--- a/Sources/App/Utilities/Request+Validator.swift
+++ b/Sources/App/Utilities/Request+Validator.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+extension Request {
+    func validate<T: ValidatableContent>(_ validatable: T) throws {
+        guard let validator = try? self.make(ValidatorService.self) else { throw ValidatorServiceError.validatorNotRegistered }
+        
+        try validator.validate(validatable)
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -51,4 +51,9 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     migrations.add(model: User.self, database: .sqlite)
     migrations.add(model: PostItem.self, database: .sqlite)
     services.register(migrations)
+    
+    // Configure validations
+    var validatorService = ValidatorService()
+    validatorService.skipValidation = env == .development
+    services.register(validatorService)
 }

--- a/Tests/AppTests/Services/ValidatorServiceTests.swift
+++ b/Tests/AppTests/Services/ValidatorServiceTests.swift
@@ -12,12 +12,23 @@ struct DummyValidatable: ValidatableContent {
     }
 }
 
+struct EvenDummierValidatable: ValidatableContent {
+    var test: String
+    
+    static func validations() throws -> Validations<EvenDummierValidatable> {
+        var validations = Validations(EvenDummierValidatable.self)
+        try validations.add(\.test, .count(3...))
+        return validations
+    }
+}
+
 
 class ValidatorServiceTests: XCTestCase {
     private var validator: ValidatorService! = nil
     
     var invalidDummy: DummyValidatable! = nil
     var validDummy: DummyValidatable! = nil
+    var invalidDummier: EvenDummierValidatable! = nil
     
     let tooShortTest = "a"
     let okTest = "aaaa"
@@ -25,6 +36,9 @@ class ValidatorServiceTests: XCTestCase {
     override func setUp() {
         self.invalidDummy = DummyValidatable(test: self.tooShortTest)
         self.validDummy = DummyValidatable(test: self.okTest)
+        
+        self.invalidDummier = EvenDummierValidatable(test: self.tooShortTest)
+        
         self.validator = ValidatorService()
     }
     
@@ -33,7 +47,7 @@ class ValidatorServiceTests: XCTestCase {
         XCTAssertNoThrow(try self.validator.validate(self.validDummy))
     }
     
-    func testShouldSkipValidation() throws {
+    func testShouldSkipAllValidations() throws {
         self.validator.skipValidation = true
         
         XCTAssertNoThrow(try self.validator.validate(self.validDummy))
@@ -45,5 +59,20 @@ class ValidatorServiceTests: XCTestCase {
         
         XCTAssertThrowsError(try self.validator.validate(self.invalidDummy))
         XCTAssertNoThrow(try self.validator.validate(self.validDummy))
+    }
+    
+    func testShouldValidateForcedEvenWhenValidationIsSkipped() throws {
+        self.validator.skipValidation = true
+        self.validator.forceValidation(of: EvenDummierValidatable.self)
+        
+        XCTAssertThrowsError(try self.validator.validate(self.invalidDummier))
+        XCTAssertNoThrow(try self.validator.validate(self.invalidDummy))
+    }
+    
+    func testShouldNotValidateIgnored() throws {
+        self.validator.ignoreValidation(of: EvenDummierValidatable.self)
+        
+        XCTAssertThrowsError(try self.validator.validate(self.invalidDummy))
+        XCTAssertNoThrow(try self.validator.validate(self.invalidDummier))
     }
 }

--- a/Tests/AppTests/Services/ValidatorServiceTests.swift
+++ b/Tests/AppTests/Services/ValidatorServiceTests.swift
@@ -1,0 +1,49 @@
+@testable import App
+import Vapor
+import XCTest
+
+struct DummyValidatable: ValidatableContent {
+    var test: String
+    
+    static func validations() throws -> Validations<DummyValidatable> {
+        var validations = Validations(DummyValidatable.self)
+        try validations.add(\.test, .count(3...))
+        return validations
+    }
+}
+
+
+class ValidatorServiceTests: XCTestCase {
+    private var validator: ValidatorService! = nil
+    
+    var invalidDummy: DummyValidatable! = nil
+    var validDummy: DummyValidatable! = nil
+    
+    let tooShortTest = "a"
+    let okTest = "aaaa"
+    
+    override func setUp() {
+        self.invalidDummy = DummyValidatable(test: self.tooShortTest)
+        self.validDummy = DummyValidatable(test: self.okTest)
+        self.validator = ValidatorService()
+    }
+    
+    func testShouldValidateWithDefaultSetting() throws {
+        XCTAssertThrowsError(try self.validator.validate(self.invalidDummy))
+        XCTAssertNoThrow(try self.validator.validate(self.validDummy))
+    }
+    
+    func testShouldSkipValidation() throws {
+        self.validator.skipValidation = true
+        
+        XCTAssertNoThrow(try self.validator.validate(self.validDummy))
+        XCTAssertNoThrow(try self.validator.validate(self.invalidDummy))
+    }
+    
+    func testShouldNotSkipValidation() throws {
+        self.validator.skipValidation = false
+        
+        XCTAssertThrowsError(try self.validator.validate(self.invalidDummy))
+        XCTAssertNoThrow(try self.validator.validate(self.validDummy))
+    }
+}


### PR DESCRIPTION
Closes #49 

I wanted to make it more configurable as I posted on the issue mentioned above.

You have option to disable all validations with changing the value of one property of `ValidatorService`

```swift
    // Configure validations
    var validatorService = ValidatorService()
    validatorService.skipValidation = env == .development
    services.register(validatorService)
```

Then, for validation, you have to call an extension method on `Request` class:

```swift
func register(_ req: Request, _ registerRequest: RegisterUserRequest) throws -> Future<HTTPResponse> {
        try req.validate(registerRequest)
        // ...
}
```

There is a private method in `ValidatorService` that checks for each validation type whether it should be validated or not.

If you remove the configuration of `ValidatorService` from `configure.swift` file and try to call `req.validate(_)` it will throw an `ValidatorServiceError.validatorNotRegistered` error.